### PR TITLE
Module name matcher, repository connectivity, and documentation fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -172,6 +172,15 @@ Deleting a module
 The tool does not keep track of what modules you have installed. TO delete a
 module just delete the directory the module was extracted into.
 
+Developing or submitting patches
+--------------------------------
+
+You need the following RubyGems to run the test suite: mocha, rspec.
+
+You can run the tests with:
+
+    rake spec
+
 Get involved
 ------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -175,7 +175,7 @@ module just delete the directory the module was extracted into.
 Developing or submitting patches
 --------------------------------
 
-You need the following RubyGems to run the test suite: mocha, rspec.
+You need the following RubyGems to run the test suite: `mocha`, `rspec`.
 
 You can run the tests with:
 

--- a/lib/puppet/module/tool.rb
+++ b/lib/puppet/module/tool.rb
@@ -46,7 +46,7 @@ module Puppet
         @repository ||= Repository.new(Puppet.settings[:puppet_module_repository])
       end
 
-      FULL_NAME_PATTERN = /\A(.+)[\/\-](.+)\z/
+      FULL_NAME_PATTERN = /\A([^-\/|.]+)[-|\/](.+)\z/
 
       # Return the +username+ and +modname+ for a given +full_name+, or raise an
       # ArgumentError if the argument isn't parseable.

--- a/lib/puppet/module/tool/repository.rb
+++ b/lib/puppet/module/tool/repository.rb
@@ -39,7 +39,7 @@ module Puppet::Module::Tool
         Net::HTTP.start(@uri.host, @uri.port) do |http|
           http.request(request)
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, SocketError
         abort "Could not reach remote repository"
       end
     end

--- a/lib/puppet/module/tool/repository.rb
+++ b/lib/puppet/module/tool/repository.rb
@@ -35,8 +35,12 @@ module Puppet::Module::Tool
 
     # Return a Net::HTTPResponse read from this HTTPRequest +request+.
     def read_contact(request)
-      Net::HTTP.start(@uri.host, @uri.port) do |http|
-        http.request(request)
+      begin
+        Net::HTTP.start(@uri.host, @uri.port) do |http|
+          http.request(request)
+        end
+      rescue Errno::ECONNREFUSED
+        abort "Could not reach remote repository"
       end
     end
 


### PR DESCRIPTION
Hey there,
I've fixed FULL_NAME_PATTERN to correctly split on '-' or '/'. Previously, modules with -'s in their names (e.g. user-my-module) cause puppet-module-tool to interpret them as:

```
user = 'user-my' 
module_name = 'module'
```

Additionally, I've added an rescue around `Puppet::Module::Tool::Repository.read_connect` to handle the remote repository not being there. 

Also, a minor documentation update. 

Cheers!
