### PR TITLE
Ticket/master/4 semver support

### DIFF
--- a/lib/puppet/module/tool/applications/application.rb
+++ b/lib/puppet/module/tool/applications/application.rb
@@ -70,10 +70,8 @@ module Puppet::Module::Tool
         unless @username && @module_name
           abort "Username and Module name not provided"
         end
-        begin
-          Gem::Version.new(@version)
-        rescue ArgumentError => e
-          abort "Invalid version format: #{@version}"
+        if @version !~ /^(\d+)\.(\d+)\.(\d+)$|^(\d)+\.(\d)+\.(\d+)([a-zA-Z][a-zA-Z0-9-]*)$/ then
+          abort "Invalid version format: #{@version} (Semantic Versions are acceptable: http://semver.org)"
         end
       end
     end

--- a/lib/puppet/module/tool/applications/application.rb
+++ b/lib/puppet/module/tool/applications/application.rb
@@ -77,7 +77,7 @@ module Puppet::Module::Tool
         end
       end
     end
-    
+
   end
-  
+
 end

--- a/spec/unit/semver_spec.rb
+++ b/spec/unit/semver_spec.rb
@@ -1,0 +1,33 @@
+# Tested this spec test with rspec 2.5.1
+
+require 'puppet/module/tool'
+
+describe Puppet::Module::Tool::Applications::Application do
+
+  describe 'app' do
+
+    good_versions = %w{ 1.2.4 0.0.1 0.0.0 0.0.2git-8-g3d316d1 0.0.3b1 10.100.10000
+                         0.1.2rc1 0.1.2dev-1 0.1.2svn12345 }
+    bad_versions = %w{ 0.1.2-3 0.1 0 0.1.2.3 dev }
+
+    before do
+      @app = Class.new(described_class).new
+    end
+
+    good_versions.each do |ver|
+      it "should accept version string #{ver}" do
+        @app.instance_eval("@filename=%q{puppetlabs-ntp-#{ver}}")
+        @app.parse_filename!
+      end
+    end
+
+    bad_versions.each do |ver|
+      it "should not accept version string #{ver}" do
+        @app.instance_eval("@filename=%q{puppetlabs-ntp-#{ver}}")
+        lambda { @app.parse_filename! }.should raise_error
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
commit d72a4ba001b5787088f3ecc0cbcc3df12f219e65
Author: Jeff McCune jeff@puppetlabs.com
Date:   Thu Jun 16 15:50:59 2011 -0700

```
(#4) Add semver support rspec tests

These unit tests validate a series of "good" version strings and
properly handled and a series of "bad" version strings raise an error as
expected.

Run with rspec semver_spec.rb with rspec 2.5.1
```

commit 3374e411376ab20c69c7f8fe11737425e9d0c505
Author: Jeff McCune jeff@puppetlabs.com
Date:   Thu Jun 16 15:27:51 2011 -0700

```
(#4) Add semantic version support

This change replaces the validation of the version string using
Gem::Version.new() with a regular expression matching the semver.org
description of versions.

The reason for this change is that Gem::Version.new() is too restrictive
and does not allow semantic version strings to be used.  We're trying to
use semantic versions for modules and for development releases these may
be in the form of 0.0.2git-8-g3d316d1
```
