### PR TITLE
(#6) Install modules to their name not "full name"

### DIFF
--- a/lib/puppet/module/tool/applications/unpacker.rb
+++ b/lib/puppet/module/tool/applications/unpacker.rb
@@ -19,7 +19,16 @@ module Puppet::Module::Tool
       end
 
       def run
-        check_clobber!
+        # Check if the module directory already exists.
+        if File.exist?(@module_name) then
+          if force? then
+            FileUtils.rm_rf @module_name rescue nil
+          else
+            check_clobber!
+            # JJM 2011-06-20 And remove it anyway (This is a dumb way to do it, but...  it works.)
+            FileUtils.rm_rf @module_name rescue nil
+          end
+        end
         build_dir = Puppet::Module::Tool::Cache.base_path + "tmp-unpacker-#{Digest::SHA1.hexdigest(@filename.basename.to_s)}"
         build_dir.mkpath
         begin
@@ -31,21 +40,19 @@ module Puppet::Module::Tool
           end
           # grab the first directory
           extracted = build_dir.children.detect { |c| c.directory? }
-          if force?
-            FileUtils.rm_rf @full_name rescue nil
-          end
-          FileUtils.cp_r extracted, @full_name
+          # Nothing should exist at this point named @module_name
+          FileUtils.cp_r extracted, @module_name
           tag_revision
         ensure
           build_dir.rmtree
         end
-        say "Installed #{@release_name.inspect} into directory: #{@full_name}"
+        say "Installed #{@release_name.inspect} into directory: #{@module_name}"
       end
 
       private
 
       def tag_revision
-        File.open("#{@full_name}/REVISION", 'w') do |f|
+        File.open("#{@module_name}/REVISION", 'w') do |f|
           f.puts "module: #{@username}/#{@module_name}"
           f.puts "version: #{@version}"
           f.puts "url: file://#{@filename.realpath}"
@@ -54,9 +61,9 @@ module Puppet::Module::Tool
       end
 
       def check_clobber!
-        if File.directory?(@full_name) && !force?
-          header "Existing module '#{@full_name}' found"
-          response = prompt "Overwrite module installed at ./#{@full_name}? [y/N]"
+        if File.exist?(@module_name) && !force?
+          header "Existing module '#{@module_name}' found"
+          response = prompt "Overwrite module installed at ./#{@module_name}? [y/N]"
           unless response =~ /y/i
             abort "Aborted installation."
           end

--- a/lib/puppet/module/tool/applications/unpacker.rb
+++ b/lib/puppet/module/tool/applications/unpacker.rb
@@ -20,7 +20,7 @@ module Puppet::Module::Tool
 
       def run
         # Check if the module directory already exists.
-        if File.exist?(@module_name) then
+        if File.exist?(@module_name) || File.symlink?(@module_name) then
           if force? then
             FileUtils.rm_rf @module_name rescue nil
           else
@@ -61,7 +61,7 @@ module Puppet::Module::Tool
       end
 
       def check_clobber!
-        if File.exist?(@module_name) && !force?
+        if (File.exist?(@module_name) || File.symlink?(@module_name)) && !force?
           header "Existing module '#{@module_name}' found"
           response = prompt "Overwrite module installed at ./#{@module_name}? [y/N]"
           unless response =~ /y/i


### PR DESCRIPTION
Without this change, the puppet-module tool installs modules into
directories named of the format author-modulename.  This is problematic
because the Puppet autoloader convention causes Puppet to expect a class
named "mcollective" in a directory named "mcollective" in
manifests/init.pp in the module.

As a result, all modules should be installed into a directory with their
specific module name, NOT a directory prefixed with the author of the
module and a hyphen.

This change replaces the use of the "full_name" with only the
"module_name" instance variables in the Unpacker class.
