### PR TITLE
use Net::HTTP::Proxy instead of Net::HTTP

### DIFF
--- a/lib/puppet/module/tool.rb
+++ b/lib/puppet/module/tool.rb
@@ -67,6 +67,14 @@ module Puppet
       def self.changelog_filename
         return File.expand_path(File.join(self.root, 'CHANGES.markdown'))
       end
+
+      # Read HTTP proxy configurationm from Puppet's config file.
+      def self.http_proxy_host
+          @http_proxy_host ||= Puppet.settings[:http_proxy_host]
+      end
+      def self.http_proxy_port
+          @http_proxy_port ||= Puppet.settings[:http_proxy_port]
+      end
     end
   end
 end

--- a/lib/puppet/module/tool/repository.rb
+++ b/lib/puppet/module/tool/repository.rb
@@ -36,7 +36,10 @@ module Puppet::Module::Tool
     # Return a Net::HTTPResponse read from this HTTPRequest +request+.
     def read_contact(request)
       begin
-        Net::HTTP.start(@uri.host, @uri.port) do |http|
+        Net::HTTP::Proxy(
+            Puppet::Module::Tool::http_proxy_host,
+            Puppet::Module::Tool::http_proxy_port
+            ).start(@uri.host, @uri.port) do |http|
           http.request(request)
         end
       rescue Errno::ECONNREFUSED, SocketError


### PR DESCRIPTION
hey folks,  

my puppetmaster is behind a HTTP proxy, and so puppet-module doesn't work completely out of the box.  i can get some functionality by setting $http_proxy, but in particular Puppet::Module::Tool::Repository uses Net::HTTP instead of calling OpenURI, and Net::HTTP doesn't pay attention to the $http_proxy environment variable.

this patch makes Puppet::Module::Tool::Repository read its proxy settings from the Puppet config (or any other config provided on the command line) and use a HTTP proxy if any is present.

-steve
