### PR TITLE
(#4847) Add support for http_proxy environment variable for http requests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,6 +74,11 @@ end
 
 task :default => :spec
 
+# Aliases for rvm
+task :specs => :spec
+task :tests => :spec
+task :test => :spec
+
 require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
     version = File.read('VERSION')

--- a/lib/puppet/module/tool.rb
+++ b/lib/puppet/module/tool.rb
@@ -68,12 +68,34 @@ module Puppet
         return File.expand_path(File.join(self.root, 'CHANGES.markdown'))
       end
 
-      # Read HTTP proxy configurationm from Puppet's config file.
+      # Read HTTP proxy configurationm from Puppet's config file, or the
+      # http_proxy environment variable.
+      def self.http_proxy_env
+        proxy_env = ENV["http_proxy"] || ENV["HTTP_PROXY"] || nil
+        begin
+          return URI.parse(proxy_env) if proxy_env
+        rescue URI::InvalidURIError
+          return nil
+        end
+        return nil
+      end
       def self.http_proxy_host
-          @http_proxy_host ||= Puppet.settings[:http_proxy_host]
+        env = http_proxy_env
+
+        if env and env.host then
+          return env.host
+        end
+
+        return Puppet.settings[:http_proxy_host]
       end
       def self.http_proxy_port
-          @http_proxy_port ||= Puppet.settings[:http_proxy_port]
+        env = http_proxy_env
+
+        if env and env.port then
+          return env.port
+        end
+
+        return Puppet.settings[:http_proxy_port]
       end
     end
   end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 # Directory that contains sample releases.
 RELEASE_FIXTURES_DIR = File.join(File.dirname(File.expand_path(__FILE__)), "..", "fixtures", "releases")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,10 @@ require 'rspec'
 
 require 'puppet/module/tool'
 
-Dir[File.join(File.dirname(__FILE__), 'support', '*.rb')].each do |support_file|
-  require support_file
-end
-
 RSpec.configure do |config|
   config.mock_with :mocha
+end
+
+Dir[File.join(File.dirname(__FILE__), 'support', '*.rb')].each do |support_file|
+  require support_file
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe Puppet::Module::Tool::Applications::Application do
 

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -1,4 +1,5 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
+require 'net/http'
 
 describe Puppet::Module::Tool::Repository do
   describe 'instances' do
@@ -8,13 +9,16 @@ describe Puppet::Module::Tool::Repository do
 
     describe '#contact' do
       before do
+        # Do a mock of the Proxy call so we can do proper expects for
+        # Net::HTTP
+        Net::HTTP.expects(:Proxy).returns(Net::HTTP)
         Net::HTTP.expects(:start)
       end
       context "when not given an :authenticate option" do
         it "should authenticate" do
           @repository.expects(:authenticate).never
           @repository.contact(nil)
-        end        
+        end
       end
       context "when given an :authenticate option" do
         it "should authenticate" do
@@ -28,13 +32,13 @@ describe Puppet::Module::Tool::Repository do
       before do
         @request = stub
         @repository.expects(:header)
-        @repository.expects(:prompt).twice        
+        @repository.expects(:prompt).twice
       end
 
       it "should set basic auth on the request" do
         @request.expects(:basic_auth)
         @repository.authenticate(@request)
-      end      
+      end
     end
 
     describe '#retrieve' do
@@ -46,6 +50,6 @@ describe Puppet::Module::Tool::Repository do
         @repository.retrieve(@uri)
       end
     end
-    
+
   end
 end

--- a/spec/unit/tool_spec.rb
+++ b/spec/unit/tool_spec.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe Puppet::Module::Tool do
+
+  describe 'http_proxy support' do
+    before :each do
+      ENV["http_proxy"] = nil
+    end
+
+    after :each do
+      ENV["http_proxy"] = nil
+    end
+
+    it "should support environment variable for port and host" do
+      ENV["http_proxy"] = "http://test.com:8011"
+      described_class.http_proxy_host.should == "test.com"
+      described_class.http_proxy_port.should == 8011
+    end
+
+    it "should support puppet configuration for port and host" do
+      ENV["http_proxy"] = nil
+      Puppet.settings.expects(:[]).with(:http_proxy_host).returns('test.com')
+      Puppet.settings.expects(:[]).with(:http_proxy_port).returns(7456)
+
+      described_class.http_proxy_port.should == 7456
+      described_class.http_proxy_host.should == "test.com"
+    end
+
+    it "should use environment variable before puppet settings" do
+      ENV["http_proxy"] = "http://test1.com:8011"
+      Puppet.settings.stubs(:[]).with(:http_proxy_host).returns('test2.com')
+      Puppet.settings.stubs(:[]).with(:http_proxy_port).returns(7456)
+
+      described_class.http_proxy_host.should == "test1.com"
+      described_class.http_proxy_port.should == 8011
+    end
+  end
+
+end


### PR DESCRIPTION
Previously we added support for using a HTTP proxy specific in puppet's
configuration file. This patch adds support for the environment variable
'http_proxy' as an override.

This also fixes the broken tests for proxy support and gets rake spec working
again as it should with rspec 2.7.x.
