### PR TITLE
(#10438) Extract installed modules to the module path by default

### DIFF
--- a/lib/puppet/module/tool.rb
+++ b/lib/puppet/module/tool.rb
@@ -36,6 +36,10 @@ module Puppet
         @version ||= (root + 'VERSION').read
       end
 
+      def self.install_dir
+        @install_dir ||= Pathname.new(Puppet.settings[:puppet_module_install_dir])
+      end
+
       # Return Pathname for this tool's working directory.
       def self.working_dir
         @working_dir ||= Pathname.new(Puppet.settings[:puppet_module_working_dir])

--- a/lib/puppet/module/tool/applications.rb
+++ b/lib/puppet/module/tool/applications.rb
@@ -13,6 +13,6 @@ module Puppet::Module::Tool
     require 'puppet/module/tool/applications/searcher'
     require 'puppet/module/tool/applications/unpacker'
     require 'puppet/module/tool/applications/unreleaser'
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/checksummer.rb
+++ b/lib/puppet/module/tool/applications/checksummer.rb
@@ -7,7 +7,7 @@ module Puppet::Module::Tool
         @path = Pathname.new(path)
         super(options)
       end
-      
+
       def run
         if metadata_file.exist?
           sums = Checksums.new(@path)

--- a/lib/puppet/module/tool/applications/cleaner.rb
+++ b/lib/puppet/module/tool/applications/cleaner.rb
@@ -2,7 +2,7 @@ module Puppet::Module::Tool
   module Applications
 
     class Cleaner < Application
-      
+
       def run
         Puppet::Module::Tool::Cache.clean
         puts "Cleaned module cache."

--- a/lib/puppet/module/tool/applications/freezer.rb
+++ b/lib/puppet/module/tool/applications/freezer.rb
@@ -7,7 +7,7 @@ module Puppet::Module::Tool
       def skeleton
         @skeleton ||= Skeleton.new
       end
-        
+
       def run
         header "Freezing in #{skeleton.custom_path}"
         skeleton.freeze!
@@ -15,6 +15,6 @@ module Puppet::Module::Tool
       end
 =end
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/generator.rb
+++ b/lib/puppet/module/tool/applications/generator.rb
@@ -43,7 +43,7 @@ module Puppet::Module::Tool
           end
         end
       end
-      
+
       def destination
         @destination ||= Pathname.new(@metadata.dashed_name)
       end
@@ -114,8 +114,8 @@ module Puppet::Module::Tool
           FileUtils.cp(@source, target)
         end
       end
-      
+
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/installer.rb
+++ b/lib/puppet/module/tool/applications/installer.rb
@@ -78,6 +78,6 @@ module Puppet::Module::Tool
       end
 
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/installer.rb
+++ b/lib/puppet/module/tool/applications/installer.rb
@@ -42,7 +42,7 @@ module Puppet::Module::Tool
             rescue OpenURI::HTTPError => e
               abort "Could not install module: #{e.message}"
             end
-            Unpacker.run(cache_path, Dir.pwd, options)
+            Unpacker.run(cache_path, options)
           else
             abort "Malformed response from module repository."
           end
@@ -50,7 +50,7 @@ module Puppet::Module::Tool
           repository = Repository.new('file:///')
           uri = URI.parse("file://#{File.expand_path(@filename)}")
           cache_path = repository.retrieve(uri)
-          Unpacker.run(cache_path, Dir.pwd, options)
+          Unpacker.run(cache_path, options)
         else
           abort "Could not determine installation source"
         end

--- a/lib/puppet/module/tool/applications/registrar.rb
+++ b/lib/puppet/module/tool/applications/registrar.rb
@@ -29,6 +29,6 @@ module Puppet::Module::Tool
       end
 =end
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/releaser.rb
+++ b/lib/puppet/module/tool/applications/releaser.rb
@@ -43,6 +43,6 @@ module Puppet::Module::Tool
       end
 =end
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/applications/searcher.rb
+++ b/lib/puppet/module/tool/applications/searcher.rb
@@ -28,7 +28,7 @@ module Puppet::Module::Tool
           say "Could not execute search (HTTP #{response.code})"
         end
       end
-      
+
     end
   end
 end

--- a/lib/puppet/module/tool/applications/unreleaser.rb
+++ b/lib/puppet/module/tool/applications/unreleaser.rb
@@ -24,7 +24,7 @@ module Puppet::Module::Tool
       end
 
       private
-      
+
       def validate!
         unless @username && @module_name
           abort "Username and Module name not provided"
@@ -37,6 +37,6 @@ module Puppet::Module::Tool
       end
 =end
     end
-    
+
   end
 end

--- a/lib/puppet/module/tool/checksums.rb
+++ b/lib/puppet/module/tool/checksums.rb
@@ -45,7 +45,7 @@ module Puppet::Module::Tool
     def annotate(metadata)
       metadata.checksums.replace(data)
     end
-    
+
     # TODO: Move the Checksummer#run checksum checking to here?
 
   end

--- a/lib/puppet/module/tool/cli.rb
+++ b/lib/puppet/module/tool/cli.rb
@@ -9,11 +9,11 @@ end
 # This class is used by the command-line program to dispatch actions.
 class Puppet::Module::Tool::CLI < Thor
   include Thor::Actions
-  
+
   map '-V' => :version
 
   class_option :config, :aliases => '-c', :default => Puppet.settings[:config], :desc => "Configuration file"
-  
+
   def self.method_option_repository
     method_option :puppet_module_repository, :aliases => '-r', :default => Puppet.settings[:puppet_module_repository], :desc => "Module repository to use"
   end
@@ -123,5 +123,5 @@ class Puppet::Module::Tool::CLI < Thor
       abort "Could not find a valid module at #{path ? path.inspect : 'current directory'}"
     end
   end
-  
+
 end

--- a/lib/puppet/module/tool/cli.rb
+++ b/lib/puppet/module/tool/cli.rb
@@ -1,8 +1,4 @@
-begin
-  require 'thor'
-rescue LoadError
-  abort "Requires 'thor'"
-end
+require 'thor'
 
 # = CLI
 #

--- a/lib/puppet/module/tool/contents_description.rb
+++ b/lib/puppet/module/tool/contents_description.rb
@@ -78,7 +78,7 @@ module Puppet::Module::Tool
         end
       end
     end
-    
+
   end
 
 end

--- a/lib/puppet/module/tool/dependency.rb
+++ b/lib/puppet/module/tool/dependency.rb
@@ -20,7 +20,7 @@ module Puppet::Module::Tool
       result[:repository] = @repository.to_s if @repository && ! @repository.nil?
       result.to_pson(*args)
     end
-    
+
   end
-  
+
 end

--- a/lib/puppet/module/tool/metadata.rb
+++ b/lib/puppet/module/tool/metadata.rb
@@ -57,35 +57,35 @@ module Puppet::Module::Tool
 
     def license
       @license || 'UNKNOWN'
-    end 
+    end
 
     def license=(license)
       @license = license
-    end 
+    end
 
     def summary
       @summary || 'UNKNOWN'
-    end 
+    end
 
     def summary=(summary)
       @summary = summary
-    end 
+    end
 
     def description
       @description || 'UNKNOWN'
-    end 
+    end
 
     def description=(description)
       @description = description
-    end 
+    end
 
     def project_page
       @project_page || 'UNKNOWN'
-    end 
+    end
 
     def project_page=(project_page)
       @project_page = project_page
-    end 
+    end
 
     # Return an array of the module's Puppet types, each one is a hash
     # containing :name and :doc.

--- a/lib/puppet/module/tool/skeleton.rb
+++ b/lib/puppet/module/tool/skeleton.rb
@@ -12,7 +12,7 @@ module Puppet::Module::Tool
     # end
 
     # Return Pathname with 'generate' templates.
-    def path 
+    def path
       paths.detect { |path| path.directory? }
     end
 

--- a/lib/puppet/module/tool/utils/settings.rb
+++ b/lib/puppet/module/tool/utils/settings.rb
@@ -6,21 +6,37 @@ module Puppet::Module::Tool::Utils
   module Settings
 
     def prepare_settings(options = {})
+      require 'puppet/util/run_mode'
+
       return if @settings_prepared
 
       if options[:config]
         Puppet.settings.send(:set_value, :config, options[:config], :cli)
       end
 
+      # in order to read the master's modulepath
+      change_settings_used(:master)
+
       Puppet.setdefaults(:puppet_module,
-        :puppet_module_repository => [Puppet::Module::Tool::REPOSITORY_URL, "The module repository"],
-        :puppet_module_working_dir => ['$vardir/puppet-module', "The directory in which module tool data is stored"])
+        :puppet_module_repository  => [
+          Puppet::Module::Tool::REPOSITORY_URL,
+          "The module repository"
+        ],
+        :puppet_module_working_dir => [
+          '$vardir/puppet-module',
+          "The directory into which module tool data is stored"
+        ],
+        :puppet_module_install_dir => [
+          Puppet.settings[:modulepath].split(File::PATH_SEPARATOR).first,
+          "The directory into which modules are installed"
+        ]
+      )
 
       Puppet::Module::Tool.working_dir.mkpath
 
       Puppet.settings.use(:puppet_module)
 
-      Puppet.settings.parse
+      change_settings_used(:puppet_module)
 
       [:puppet_module_repository].each do |key|
         if options[key]
@@ -29,6 +45,15 @@ module Puppet::Module::Tool::Utils
       end
 
       @settings_prepared = true
+    end
+
+    private
+
+    # The settings section we use when parsing is determined by the run_mode
+    def change_settings_used(run_mode)
+      # have to change the runmode so parse gets the right settings
+      $puppet_application_mode = Puppet::Util::RunMode[run_mode]
+      Puppet.settings.parse
     end
 
   end

--- a/lib/puppet/module/tool/utils/settings.rb
+++ b/lib/puppet/module/tool/utils/settings.rb
@@ -32,5 +32,5 @@ module Puppet::Module::Tool::Utils
     end
 
   end
-  
+
 end

--- a/spec/fixtures/releases/jamtur01-apache/files/httpd
+++ b/spec/fixtures/releases/jamtur01-apache/files/httpd
@@ -16,7 +16,7 @@
 #OPTIONS=-DDOWN
 
 #
-# By default, the httpd process is started in the C locale; to 
+# By default, the httpd process is started in the C locale; to
 # change the locale in which the server runs, the HTTPD_LANG
 # variable can be set.
 #

--- a/spec/fixtures/releases/jamtur01-apache/files/test.vhost
+++ b/spec/fixtures/releases/jamtur01-apache/files/test.vhost
@@ -5,7 +5,7 @@ NameVirtualHost *:80
 <VirtualHost *:80>
   ServerName testvhost
   DocumentRoot /tmp/testvhost
-  <Directory /tmp/testvhost> 
+  <Directory /tmp/testvhost>
     Options Indexes FollowSymLinks MultiViews
     AllowOverride None
     Order allow,deny

--- a/spec/fixtures/releases/jamtur01-apache/lib/puppet/provider/a2mod/debian.rb
+++ b/spec/fixtures/releases/jamtur01-apache/lib/puppet/provider/a2mod/debian.rb
@@ -1,21 +1,21 @@
 Puppet::Type.type(:a2mod).provide(:debian) do
     desc "Manage Apache 2 modules on Debian-like OSes (e.g. Ubuntu)"
- 
+
     commands :encmd => "a2enmod"
     commands :discmd => "a2dismod"
- 
+
     defaultfor :operatingsystem => [:debian, :ubuntu]
 
     def create
         encmd resource[:name]
     end
- 
+
     def destroy
         discmd resource[:name]
     end
- 
+
     def exists?
-        mod= "/etc/apache2/mods-enabled/" + resource[:name] + ".load" 
+        mod= "/etc/apache2/mods-enabled/" + resource[:name] + ".load"
         File.exists?(mod)
     end
 end

--- a/spec/fixtures/releases/jamtur01-apache/lib/puppet/type/a2mod.rb
+++ b/spec/fixtures/releases/jamtur01-apache/lib/puppet/type/a2mod.rb
@@ -1,6 +1,6 @@
 Puppet::Type.newtype(:a2mod) do
     @doc = "Manage Apache 2 modules"
- 
+
     ensurable
 
     newparam(:name) do
@@ -8,5 +8,5 @@ Puppet::Type.newtype(:a2mod) do
 
        isnamevar
 
-    end 
+    end
 end

--- a/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
@@ -1,7 +1,7 @@
 # ensure apache is installed
 class apache {
   include apache::params
-  package{'httpd': 
+  package{'httpd':
     name   => $apache::params::apache_name,
     ensure => present,
   }
@@ -30,5 +30,5 @@ class apache {
     recurse => true,
     purge => true,
     notify => Service['httpd'],
-  } 
+  }
 }

--- a/spec/fixtures/releases/jamtur01-apache/manifests/params.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/params.pp
@@ -1,7 +1,7 @@
 class apache::params{
   $user  = 'www-data'
   $group = 'www-data'
-  
+
   case $operatingsystem {
     "centos": {
        $apache_name = httpd

--- a/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp
@@ -1,7 +1,7 @@
 class apache::ssl {
   include apache
 
-  
+
   case $operatingsystem {
      "centos": {
         package { $apache::params::ssl_package:

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -180,7 +180,7 @@ describe "cli" do
             dependency1['version_requirement'].should == dependency1_requirement
             dependency1['repository'].should be_nil
           end
-          
+
           dependencies[1].tap do |dependency2|
             dependency2['name'].should == dependency2_name
             dependency2['version_requirement'].should == dependency2_requirement

--- a/spec/support/output_support.rb
+++ b/spec/support/output_support.rb
@@ -10,7 +10,7 @@ def output_for(&block)
   $stderr = output
 
   block.call
-  
+
   output.rewind
   return output.read
 ensure


### PR DESCRIPTION
```
The current behavior is to only allow the module to install to the
current working directory.  This makes the install destination
configurable both from inside your puppet.conf and from the command
line.

There were some concerns about the default being your module path.  Here
are those concerns and why it was decided to default to the modulepath
anyway.

Objections
* Installing directly to the module path in production may not be what
  you want.  However, just installing a module shouldn't do anything
  until you actually include it's classes in your manifests.
* The modulepath might have more than one directory in it.  We just use
  the first one.  This will require a PE change so it's modulepath is
  useful for this assumption.
* If you're want to download a module to develop it you don't want it in
  the module path.  I think if you want to develop a module you want to
  run it to test it also, and your modulepath will probably already be
  version controlled.

Pros
* One of the trickiest things for new users is installing modules to the
  right location, and this helps with that a lot.
* Experienced users can configure whatever they want easily from the
  command line.

There was some trickiness with getting the settings right from Puppet
since you have to mess with the run_mode global setting and reparse the
settings.  The code was already trying to use Puppet settings, but
wasn't dealing with the run_mode correctly, so now the settings that
were already defined should work too.
```
