### PR TITLE
(#10438) Add install_dir to the command line

### DIFF
--- a/lib/puppet/module/tool/cli.rb
+++ b/lib/puppet/module/tool/cli.rb
@@ -60,6 +60,7 @@ class Puppet::Module::Tool::CLI < Thor
   desc "install MODULE_NAME_OR_FILE [OPTIONS]", "Install a module (eg, 'user-modname') from a repository or file"
   method_option :version, :alias => :v, :desc => "Version to install (can be a requirement, eg '>= 1.0.3', defaults to latest version)"
   method_option :force, :alias => :f, :type => :boolean, :desc => "Force overwrite of existing module, if any"
+  method_option :install_dir, :alias => :i, :desc => "The directory into which modules are installed"
   method_option_repository
   def install(name)
     Puppet::Module::Tool::Applications::Installer.run(name, options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,25 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'rspec'
-
 require 'puppet/module/tool'
+require 'tmpdir'
+require 'fileutils'
 
 RSpec.configure do |config|
   config.mock_with :mocha
+
+  config.before :each do
+    Puppet.settings.stubs(:parse)
+  end
+
+  config.before :all do
+    @tmp_confdir = Puppet[:confdir] = Dir.mktmpdir
+    @tmp_vardir = Puppet[:vardir] = Dir.mktmpdir
+  end
+
+  config.after :all do
+    FileUtils.rm_r [@tmp_confdir, @tmp_vardir]
+  end
 end
 
 Dir[File.join(File.dirname(__FILE__), 'support', '*.rb')].each do |support_file|


### PR DESCRIPTION
The previous commit for #10438 to have a configurable install dir forgot
to put the command line option in.  This commit does that.

It also adds some code to the spec helper to prevent the specs from
interacting with puppet's actual vardir.  This was necessary to make the
test for the install_dir option workable, and it's just a good thing
besides.
