### PR TITLE
(#11151) Fix attempted connection to "none" HTTP proxy

### DIFF
--- a/lib/puppet/module/tool.rb
+++ b/lib/puppet/module/tool.rb
@@ -90,7 +90,11 @@ module Puppet
           return env.host
         end
 
-        return Puppet.settings[:http_proxy_host]
+        host = Puppet.settings[:http_proxy_host]
+        if host != "none" then
+          return host
+        end
+        nil
       end
       def self.http_proxy_port
         env = http_proxy_env

--- a/lib/puppet/module/tool/repository.rb
+++ b/lib/puppet/module/tool/repository.rb
@@ -42,8 +42,8 @@ module Puppet::Module::Tool
             ).start(@uri.host, @uri.port) do |http|
           http.request(request)
         end
-      rescue Errno::ECONNREFUSED, SocketError
-        abort "Could not reach remote repository"
+      rescue Errno::ECONNREFUSED, SocketError => e
+        abort "Could not reach remote repository at #{@uri}: #{e}"
       end
     end
 

--- a/spec/unit/tool_spec.rb
+++ b/spec/unit/tool_spec.rb
@@ -13,6 +13,14 @@ describe Puppet::Module::Tool do
       ENV["http_proxy"] = nil
     end
 
+    it "should handle no proxy with defaults" do
+      Puppet.settings.expects(:[]).with(:http_proxy_host).returns('none')
+      Puppet.settings.expects(:[]).with(:http_proxy_port).returns(3128)
+
+      described_class.http_proxy_host.should == nil
+      described_class.http_proxy_port.should == 3128
+    end
+
     it "should support environment variable for port and host" do
       ENV["http_proxy"] = "http://test.com:8011"
       described_class.http_proxy_host.should == "test.com"


### PR DESCRIPTION
Handle the default Puppet HTTP proxy hostname being the string "none".  Same logic as Puppet's 
lib/puppet/network/http_pool.rb.

http://projects.puppetlabs.com/issues/11151
