### PR TITLE
Add gitignore to default puppet module

### DIFF
--- a/lib/puppet/module/tool/applications/generator.rb
+++ b/lib/puppet/module/tool/applications/generator.rb
@@ -71,6 +71,9 @@ module Puppet::Module::Tool
         def target
           target = @generator.destination + @source.relative_path_from(@generator.skeleton.path)
           components = target.to_s.split(File::SEPARATOR).map do |part|
+            if part[0] == '_'
+              part[0] = '.'
+            end
             part == 'NAME' ? @generator.metadata.name : part
           end
           Pathname.new(components.join(File::SEPARATOR))

--- a/templates/generator/_gitignore
+++ b/templates/generator/_gitignore
@@ -1,0 +1,15 @@
+## MAC OS
+.DS_Store
+
+## TEXTMATE
+*.tmproj
+tmtags
+
+## EMACS
+*~
+\#*
+.\#*
+
+## VIM
+*.swp
+tags


### PR DESCRIPTION
Many people using this tool are checking files into git and are not good
at housekeeping.  Lots of modules have editor temp files stored in their
git repos.  This patch adds some magic that will rename files starting with
_ to dotfiles in the target directory.

Feel free to kick this to the curb if you don't agree with my approach or don't
feel that the default should include a gitignore.
