### PR TITLE
Add options to generate

### DIFF
--- a/lib/puppet/module/tool/applications/generator.rb
+++ b/lib/puppet/module/tool/applications/generator.rb
@@ -33,6 +33,8 @@ module Puppet::Module::Tool
           if path == skeleton
             destination.mkpath
           else
+            next if (path.fnmatch?('*/spec*') &&
+                     (@options[:exclude_spec] || @options[:rspec_puppet_generator]))
             node = Node.on(path, self)
             if node
               node.install!
@@ -41,6 +43,13 @@ module Puppet::Module::Tool
               say "Could not generate from #{path}"
             end
           end
+        end
+        if(@options[:rspec_puppet_generator])
+          old_pwd = Dir.pwd
+          Dir.chdir destination
+          require 'rspec-puppet'
+          RSpec::Puppet::Setup.run
+          Dir.chdir old_pwd 
         end
       end
 

--- a/lib/puppet/module/tool/cli.rb
+++ b/lib/puppet/module/tool/cli.rb
@@ -19,7 +19,9 @@ class Puppet::Module::Tool::CLI < Thor
     say Puppet::Module::Tool.version
   end
 
-  desc "generate USERNAME-MODNAME", "Generate boilerplate for a new module"
+  desc "generate USERNAME-MODNAME [OPTIONS]", "Generate boilerplate for a new module"
+  method_option :exclude_spec, :aliases => '-X', :type => :boolean, :desc => "Exclude RSpec tests."
+  method_option :rspec_puppet_generator, :aliases => '-R', :type => :boolean, :desc => "Use rspec-puppet generator."
   method_option_repository
   def generate(name)
     Puppet::Module::Tool::Applications::Generator.run(name, options)


### PR DESCRIPTION
This is basically a feature request for the 'generate' method. I prefer to use the generator from rspec-puppet so I've added the following options:

Add option to generate RSpec via rspec-puppet (-R).
Add option to exclude RSpec tests (-X).

Let me know if this looks OK. If not, no big deal...

Cheers,

Dan Wanek
