### PR TITLE
added file and template examples

### DIFF
--- a/templates/generator/files/example.file.erb
+++ b/templates/generator/files/example.file.erb
@@ -1,0 +1,13 @@
+# This file is maintained by puppet
+# DO NOT EDIT !
+# all changes will be overridden
+
+# Download the content of this file by
+#
+# file {
+#   'path/to/file/on/node':
+#     ensure => present,
+#     source => 'puppet:///modules/<%= metadata.name %>/example.file'
+# }
+#
+

--- a/templates/generator/templates/example.erb.erb
+++ b/templates/generator/templates/example.erb.erb
@@ -1,0 +1,24 @@
+# This file is maintained by puppet
+# DO NOT EDIT !
+# all changes will be overridden
+
+#
+# Get the content of this file:
+#
+# # declare variables in your puppet script
+#
+# ...
+# $myVar = 'foo'
+# ...
+# 
+# # declare a file 
+#
+# file {
+#   'path/to/file/on/node':
+#     ensure => present,
+#     content => template("<%= metadata.name %>/example.erb")
+# }
+#
+# Use declared variables in this template (see http://docs.puppetlabs.com/guides/templating.html)
+#
+


### PR DESCRIPTION
I am missing pregenerated files and templates folders. Examples put in there could be helpfull.

For the 

puppet-module generate

command, I would like to introduce options like 

--with-files
--with-templates
--with-lib
--with-specs

What do you think?
